### PR TITLE
feat: rollback and resume

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const CouchContinuum = require('.')
+const readline = require('readline')
 
 const prefix = '[couch-continuum]'
 function log () {
@@ -9,43 +10,101 @@ function log () {
   console.log.apply(console, arguments)
 }
 
+function getConsent () {
+  const question = 'Ready to replace the primary with the replica. Continue? [y/N] '
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      const consent = answer.match(/^y$/i)
+      return resolve(consent)
+    })
+  })
+}
+
 require('yargs')
   .command({
-    command: '$0',
-    aliases: ['start'],
-    builder: function (yargs) {
-      yargs.options({
-        couchUrl: {
-          alias: 'u',
-          description: 'The URL of the CouchDB cluster to act upon.',
-          default: process.env.COUCH_URL || 'http://localhost:5984'
-        },
-        dbName: {
-          alias: 'n',
-          description: 'The name of the database to modify.',
-          required: true,
-          type: 'string'
-        },
-        q: {
-          description: 'The desired "q" value for the new database.',
-          required: true,
-          type: 'number'
-        },
-        verbose: {
-          alias: 'v',
-          description: 'Enable verbose logging.',
-          type: 'boolean'
-        }
-      })
-    },
+    command: 'start',
+    aliases: ['$0'],
+    description: 'Migrate a database to new settings.',
     handler: function (argv) {
-      const { couchUrl, dbName, q, verbose } = argv
+      const { couchUrl, dbName, copyName, q, verbose } = argv
       if (verbose) process.env.LOG = true
-      const continuum = new CouchContinuum({ couchUrl, dbName, q })
+      const options = { couchUrl, dbName, copyName, q }
+      const continuum = new CouchContinuum(options)
       log(`Migrating database '${dbName}' to { q: ${q} }...`)
-      continuum.start().then(function () {
-        log('...success!')
+      continuum.createReplica().then(function () {
+        return getConsent()
+      }).then((consent) => {
+        if (!consent) return log('Could not acquire consent. Exiting...')
+        return continuum.replacePrimary().then(() => {
+          log('... success!')
+        })
       })
+    }
+  })
+  .command({
+    command: 'create-replica',
+    aliases: ['create', 'replica'],
+    description: 'Create a replica of the given primary.',
+    handler: function (argv) {
+      const { couchUrl, dbName, copyName, q, verbose } = argv
+      if (verbose) process.env.LOG = true
+      const options = { couchUrl, dbName, copyName, q }
+      const continuum = new CouchContinuum(options)
+      log(`Creating replica of ${continuum.db1} at ${continuum.db2}`)
+      continuum.createReplica().then(() => {
+        log('... success!')
+      })
+    }
+  })
+  .command({
+    command: 'replace-primary',
+    aliases: ['replace', 'primary'],
+    description: 'Replace the given primary with the indicated replica.',
+    handler: function (argv) {
+      const { couchUrl, dbName, copyName, q, verbose } = argv
+      if (verbose) process.env.LOG = true
+      const options = { couchUrl, dbName, copyName, q }
+      const continuum = new CouchContinuum(options)
+      log(`Replacing primary ${continuum.db1} with ${continuum.db2} and settings { q:${q} }`)
+      getConsent().then((consent) => {
+        if (!consent) return log('Could not acquire consent. Exiting...')
+        return continuum.replacePrimary().then(() => {
+          log('... success!')
+        })
+      })
+    }
+  })
+  .options({
+    couchUrl: {
+      alias: 'u',
+      description: 'The URL of the CouchDB cluster to act upon.',
+      default: process.env.COUCH_URL || 'http://localhost:5984'
+    },
+    dbName: {
+      alias: 'n',
+      description: 'The name of the database to modify.',
+      required: true,
+      type: 'string'
+    },
+    copyName: {
+      alias: 'c',
+      description: 'The name of the database to use as a replica. Defaults to {dbName}_temp_copy',
+      type: 'string'
+    },
+    q: {
+      description: 'The desired "q" value for the new database.',
+      required: true,
+      type: 'number'
+    },
+    verbose: {
+      alias: 'v',
+      description: 'Enable verbose logging.',
+      type: 'boolean'
     }
   })
   .config()

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const ProgressBar = require('progress')
 const request = require('request')
 
 const prefix = '[couch-continuum]'
@@ -15,174 +16,242 @@ function makeCallBack (resolve, reject) {
   return (err, res, body) => {
     if (typeof body === 'string') body = JSON.parse(body)
     if (err || body.error) return reject(err || body)
-    else return resolve()
+    else return resolve(body)
   }
+}
+
+function makeRequest (options) {
+  return new Promise((resolve, reject) => {
+    const done = makeCallBack(resolve, reject)
+    request(options, done)
+  })
 }
 
 module.exports =
 class CouchContinuum {
-  constructor ({ couchUrl, dbName, q }) {
+  constructor ({ couchUrl, dbName, copyName, q }) {
     assert(couchUrl, 'The Continuum requires a URL for accessing CouchDB.')
     assert(dbName, 'The Continuum requires a target database.')
     assert(q, 'The Continuum requires a desired "q" setting.')
     this.url = couchUrl
     this.db1 = dbName
-    this.db2 = this.db1 + '_temp_copy'
+    this.db2 = copyName || (this.db1 + '_temp_copy')
     this.q = q
   }
 
-  _checkDb (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName].join('/')
-      request({ url }, done)
-    })
-  }
-
   _createDb (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName].join('/')
-      request({
-        url,
-        method: 'PUT',
-        json: { q: this.q }
-      }, done)
+    return makeRequest({
+      url: [this.url, dbName].join('/'),
+      method: 'PUT',
+      json: { q: this.q }
     })
   }
 
   _destroyDb (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName].join('/')
-      request({
-        url,
-        method: 'DELETE'
-      }, done)
-    })
-  }
-
-  _isAvailable (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName, '_local', 'in-maintenance'].join('/')
-      request({ url }, done)
-    })
-  }
-
-  _setUnavailable (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName, '_local', 'in-maintenance'].join('/')
-      request({
-        url,
-        method: 'PUT',
-        json: { down: true }
-      }, done)
-    })
-  }
-
-  _setAvailable (dbName) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, dbName, '_local', 'in-maintenance'].join('/')
-      request({
-        url,
-        method: 'GET',
-        json: true
-      }, (err, res, doc) => {
-        if (doc.error) {
-          if (doc.error === 'not_found') return resolve()
-          else return reject(doc)
-        }
-        if (err) return reject(err)
-        request({
-          url,
-          method: 'DELETE',
-          json: { rev: doc._rev }
-        }, done)
-      })
+    return makeRequest({
+      url: [this.url, dbName].join('/'),
+      method: 'DELETE',
+      json: true
     })
   }
 
   _replicate (source, target) {
-    return new Promise((resolve, reject) => {
-      const done = makeCallBack(resolve, reject)
-      const url = [this.url, '_replicate'].join('/')
-      request({
-        url,
+    return makeRequest({
+      url: [this.url, source].join('/'),
+      json: true
+    }).then((body) => {
+      const total = body.doc_count
+      const text = '[couch-continuum] Replicating (:bar) :percent :etas'
+      const bar = new ProgressBar(text, {
+        incomplete: ' ',
+        width: 20,
+        total
+      })
+      var current = 0
+      const timer = setInterval(() => {
+        makeRequest({
+          url: [this.url, target].join('/'),
+          json: true
+        }).then((body) => {
+          const latest = body.doc_count
+          const delta = latest - current
+          bar.tick(delta)
+          current = latest
+          if (bar.complete) clearInterval(timer)
+        })
+      }, 1000)
+      return makeRequest({
+        url: [this.url, '_replicate'].join('/'),
         method: 'POST',
         json: { source, target }
-      }, done)
+      }).then(() => {
+        bar.tick(total)
+        clearInterval(timer)
+      })
     })
   }
 
-  _rollBack () {
-    log('Rolling back changes...')
-    return this._checkDb(this.db2).then(() => {
-      log('Ensuring primary exists...')
-      return this._createDb(this.db1).catch((err) => {
-        if (err.error && err.error === 'file_exists') {
-          return true
-        } else {
-          throw err
-        }
+  _verifyReplica () {
+    const getDocCount = (dbName) => {
+      return makeRequest({
+        url: [this.url, dbName].join('/'),
+        json: true
+      }).then((body) => {
+        return body.doc_count
+      })
+    }
+
+    return Promise.all([
+      getDocCount(this.db1),
+      getDocCount(this.db2)
+    ]).then(([docCount1, docCount2]) => {
+      assert.equal(docCount1, docCount2, 'Primary and replica do not have the same number of documents.')
+    })
+  }
+
+  _setUnavailable () {
+    return makeRequest({
+      url: [this.url, this.db1, '_local', 'in-maintenance'].join('/'),
+      method: 'PUT',
+      json: { down: true }
+    }).catch((error) => {
+      if (error.error === 'file_exists') return null
+      else throw error
+    })
+  }
+
+  _setAvailable () {
+    const url = [this.url, this.db1, '_local', 'in-maintenance'].join('/')
+    return makeRequest({ url, json: true }).catch((error) => {
+      if (error.error === 'not_found') return {}
+      else throw error
+    }).then(({ _rev }) => {
+      const qs = _rev ? { rev: _rev } : {}
+      return makeRequest({ url, qs, method: 'DELETE' })
+    })
+  }
+
+  /**
+   * Retrieve the update sequence for a given database.
+   * @param  {String} dbName  Name of the database to check.
+   * @return {Promise}        Resolves with the database's update sequence.
+   */
+  _getUpdateSeq (dbName) {
+    return makeRequest({
+      url: [this.url, dbName].join('/'),
+      json: true
+    }).then((body) => {
+      return body.update_seq
+    })
+  }
+
+  /**
+   * Check if a database is still receiving updates or is
+   * otherwise being monitored.
+   * @param  {String}  dbName     Name of the database to check.
+   * @return {Promise<Boolean>}   Whether the database is in use.
+   */
+  _isInUse (dbName) {
+    return Promise.all([
+      makeRequest({
+        url: [this.url, '_active_tasks'].join('/'),
+        json: true
+      }),
+      makeRequest({
+        url: [this.url, '_scheduler', 'jobs'].join('/'),
+        json: true
+      })
+    ]).then(([activeTasks, jobsResponse]) => {
+      const { jobs } = jobsResponse
+      // verify that the given dbName is not involved
+      // in any active jobs or tasks
+      jobs.concat(activeTasks).forEach(({ database }) => {
+        assert.notEqual(database, dbName, `${dbName} is still in use.`)
+      })
+    })
+  }
+
+  /**
+   * Create a replica for the migration.
+   * @return {Promise} Promise that resolves once
+   *                   the replica has been created
+   */
+  createReplica () {
+    let lastSeq1, lastSeq2
+    log(`Creating replica ${this.db2}...`)
+    log('[0/5] Checking if primary is in use...')
+    return this._isInUse(this.db1).then(() => {
+      return this._getUpdateSeq(this.db1).then((seq) => {
+        lastSeq1 = seq
       })
     }).then(() => {
-      log('Restoring documents from temp to primary...')
-      return this._replicate(this.db2, this.db1)
+      log('[1/5] Creating replica db:', this.db2)
+      return this._createDb(this.db2).catch((err) => {
+        const exists = (err.error && err.error === 'file_exists')
+        if (exists) return true
+        else throw err
+      })
     }).then(() => {
-      log('Removing temp db...')
-      return this._destroyDb(this.db2)
+      log('[2/5] Beginning replication of primary to replica...')
+      return this._replicate(this.db1, this.db2)
     }).then(() => {
-      log('Setting primary as available...')
-      return this._setAvailable(this.db1)
+      log('[3/5] Verifying primary did not change during replication...')
+      return this._getUpdateSeq(this.db1).then((seq) => {
+        lastSeq2 = seq
+        assert.equal(lastSeq1, lastSeq2, `${this.db1} is still receiving updates. Exiting...`)
+      })
+    }).then(() => {
+      log('[4/5] Verifying primary and replica match...')
+      return this._verifyReplica()
+    }).then(() => {
+      log('[5/5] Primary copied to replica.')
     })
   }
 
-  start () {
-    log('Creating temp db:', this.db2)
-    return this._createDb(this.db2).catch((err) => {
-      if (err.error && err.error === 'file_exists') {
-        return true
-      } else {
-        throw err
-      }
+  replacePrimary () {
+    log(`Replacing primary ${this.db1}...`)
+    log('[0/8] Checking if primary is in use...')
+    return this._isInUse(this.db1).then(() => {
+      log('[1/8] Verifying primary and replica match...')
+      return this._verifyReplica()
     }).then(() => {
-      log('Checking %s availability...', this.db1)
-      return this._isAvailable(this.db1).then(() => {
-        log('... %s is in maintenance!', this.db1)
-        return true
-      }).catch((err) => {
-        if (err.error && err.error === 'not_found') {
-          log('... %s is available!', this.db1)
-          log('Beginning replication of primary to temp...')
-          return this._replicate(this.db1, this.db2).then(() => {
-            log('Replicated. Destroying primary...')
-            return this._destroyDb(this.db1)
-          }).then(() => {
-            log('Recreating primary with new settings...')
-            return this._createDb(this.db1)
-          }).then(() => {
-            log('Setting primary as unavailable (again)...')
-            return this._setUnavailable(this.db1)
+      log('[2/8] Destroying primary...')
+      return this._destroyDb(this.db1)
+    }).then(() => {
+      log('[3/8] Recreating primary with new settings...')
+      return this._createDb(this.db1).then(() => {
+        return new Promise((resolve) => {
+          // sleep, giving the cluster a chance to sort
+          // out the rapid recreation.
+          const text = '[couch-continuum] Recreating (:bar) :percent :etas'
+          const bar = new ProgressBar(text, {
+            incomplete: ' ',
+            width: 20,
+            total: 150
           })
-        } else {
-          throw err
-        }
+          const timer = setInterval(() => {
+            bar.tick()
+            if (bar.complete) {
+              clearInterval(timer)
+              return resolve()
+            }
+          }, 100)
+        })
       })
     }).then(() => {
-      log('Beginning replication of temp to primary...')
+      log('[4/8] Setting primary to unavailable.')
+      return this._setUnavailable()
+    }).then(() => {
+      log('[5/8] Beginning replication of replica to primary...')
       return this._replicate(this.db2, this.db1)
     }).then(() => {
-      log('Replicated. Destroying temp...')
+      log('[6/8] Replicated. Destroying replica...')
       return this._destroyDb(this.db2)
     }).then(() => {
-      log('Setting primary as available...')
-      return this._setAvailable(this.db1)
-    }).catch((e) => {
-      log('Unexpected error: %j', e)
-      return this._rollBack()
+      log('[7/8] Setting primary to available.')
+      return this._setAvailable()
+    }).then(() => {
+      log('[8/8] Primary migrated to new settings.')
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Diana Thayer <garbados@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "progress": "^2.0.0",
     "request": "^2.83.0",
     "yargs": "^11.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -46,32 +46,24 @@ describe([name, version].join(' @ '), function () {
   })
 
   it('should work', function () {
+    this.timeout(30 * 1000) // 30s
     const options = { couchUrl, dbName, q }
     const continuum = new CouchContinuum(options)
-    return continuum.start()
-  })
-
-  it('should roll back changes', function () {
-    const options = { couchUrl, dbName, q }
-    const continuum = new CouchContinuum(options)
-    return continuum._createDb(continuum.db2).then(() => {
-      return continuum._replicate(dbName, continuum.db2)
-    }).then(() => {
-      return continuum._destroyDb(dbName)
-    }).then(() => {
-      return continuum.start()
+    return continuum.createReplica().then(() => {
+      return continuum.replacePrimary()
     })
   })
 
-  it('should handle resume', function () {
+  it('should create replicas repeatedly OK', function () {
     const options = { couchUrl, dbName, q }
     const continuum = new CouchContinuum(options)
-    return continuum._setUnavailable(dbName).then(() => {
-      return continuum._createDb(continuum.db2).then(() => {
-        return continuum._replicate(dbName, continuum.db2)
-      })
-    }).then(() => {
-      return continuum.start()
+    return continuum.createReplica().then(() => {
+      return continuum.createReplica()
     })
+  })
+
+  it('should check if a db is in use', function () {
+    const continuum = new CouchContinuum({ couchUrl, dbName, q })
+    return continuum._isInUse(dbName)
   })
 })


### PR DESCRIPTION
This PR contains the feature branches 'resume' and 'rollback' which respectively implement functionality for resuming incomplete migrations and rolling back failed ones.

Rollback catches any unexpected errors and attempts to return the database to its state before the tool started: re-creating the primary if necessary, replicating changes from the temp db to the primary, and setting it as available as necessary.

Resume detects evidence of an incomplete prior run and skips steps accordingly. For example, if db2 exists and db1 is marked as unavailable, it will skip replicating db1 to db2 and pick up replicating db2 to db1.

These features are coming in the same PR because they both depend on new private methods like `_checkDb()`.

**UPDATE**: This PR closes issues #2 and #3. 