### PR TITLE
breaking: add 'n' parameter; change alias for 'dbName' to 'N'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,12 @@
 A tool for migrating CouchDB databases. It is useful for modifying database configuration values that can only be set during database creation, like `q` and `placement`. For example:
 
 ```bash
-$ couch-continuum -n hello-world -q 4 -u http://$USER:$PASS@localhost:5984
-[couch-continuum] Migrating database 'hello-world' to new settings { q: 4 }...
-[couch-continuum] Replicating hello-world to hello-world_temp_copy
-[couch-continuum] (====================) 100% 0.0s
+$ couch-continuum -N hello-world -q 4 -n 1 -u http://$USER:$PASS@localhost:5984
+[couch-continuum] Migrating database 'hello-world'...
 Ready to replace the primary with the replica. Continue? [y/N] y
 [couch-continuum] Recreating primary hello-world
 [couch-continuum] (====================) 100% 0.0s
-[couch-continuum] Replicating hello-world_temp_copy to hello-world
-[couch-continuum] (====================) 100% 0.0s
 [couch-continuum] ... success!
-
 ```
 
 ## Why?
@@ -95,12 +90,13 @@ Options:
   --interval, -i          How often (in milliseconds) to check replication tasks
                           for progress.                          [default: 1000]
   -q                      The desired "q" value for the new database.   [number]
+  -n                      The desired "n" value for the new database.   [number]
   --verbose, -v           Enable verbose logging.                      [boolean]
   --placement, -p         Placement rule for the affected database(s).  [string]
   --filterTombstones, -f  Filter tombstones during replica creation.
                                                                 [default: false]
   --config                Path to JSON config file
-  --dbName, -n            The name of the database to modify.[string] [required]
+  --dbName, -N            The name of the database to modify.[string] [required]
   --copyName, -c          The name of the database to use as a replica. Defaults
                           to {dbName}_temp_copy                         [string]
   -h, --help              Show help                                    [boolean]
@@ -109,16 +105,13 @@ Options:
 The verbose output will inform you of each stage of the tool's operations. For example:
 
 ```
-$ couch-continuum -n hello-world -q 4 -u http://... -v
-[couch-continuum] Created new continuum: {"db1":"hello-world","db2":"hello-world_temp_copy","interval":1000,"q":4}
-[couch-continuum] Migrating database 'hello-world' to new settings { q: 4 }...
+$ couch-continuum -N hello-world -q 4 -u http://... -v
+[couch-continuum] Created new continuum: {"db1":"hello-world","db2":"hello-world_temp_copy","interval":1000,"q":4,"n":1}
+[couch-continuum] Migrating database 'hello-world'...
 [couch-continuum] Creating replica hello-world_temp_copy...
 [couch-continuum] [0/5] Checking if primary is in use...
 [couch-continuum] [1/5] Creating replica db: hello-world_temp_copy
 [couch-continuum] [2/5] Beginning replication of primary to replica...
-[couch-continuum] Replicating hello-world to hello-world_temp_copy
-[couch-continuum] (====================) 100% 0.0s
-
 [couch-continuum] [3/5] Verifying primary did not change during replication...
 [couch-continuum] [4/5] Verifying primary and replica match...
 [couch-continuum] [5/5] Primary copied to replica.
@@ -132,9 +125,6 @@ Ready to replace the primary with the replica. Continue? [y/N] y
 [couch-continuum] (====================) 100% 0.0s
 [couch-continuum] [4/8] Setting primary to unavailable.
 [couch-continuum] [5/8] Beginning replication of replica to primary...
-[couch-continuum] Replicating hello-world_temp_copy to hello-world
-[couch-continuum] (====================) 100% 0.0s
-
 [couch-continuum] [6/8] Replicated. Destroying replica...
 [couch-continuum] [7/8] Setting primary to available.
 [couch-continuum] [8/8] Primary migrated to new settings.

--- a/bin.js
+++ b/bin.js
@@ -62,7 +62,7 @@ require('yargs')
     builder: function (yargs) {
       yargs.options({
         dbName: {
-          alias: 'n',
+          alias: 'N',
           description: 'The name of the database to modify.',
           required: true,
           type: 'string'
@@ -181,6 +181,10 @@ require('yargs')
     },
     q: {
       description: 'The desired "q" value for the new database.',
+      type: 'number'
+    },
+    n: {
+      description: 'The desired "n" value for the new database.',
       type: 'number'
     },
     verbose: {

--- a/bin.js
+++ b/bin.js
@@ -15,9 +15,9 @@ function log () {
 }
 
 function getContinuum (argv) {
-  const { copyName, couchUrl, dbName, filterTombstones, interval, placement, q, verbose } = argv
+  const { copyName, couchUrl, dbName, filterTombstones, interval, n, placement, q, verbose } = argv
   if (verbose) process.env.LOG = true
-  const options = { copyName, couchUrl, dbName, filterTombstones, interval, placement, q }
+  const options = { copyName, couchUrl, dbName, filterTombstones, interval, n, placement, q }
   return new CouchContinuum(options)
 }
 

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class CouchContinuum {
     }, Promise.resolve())
   }
 
-  constructor ({ couchUrl, dbName, copyName, filterTombstones, placement, interval, q }) {
+  constructor ({ couchUrl, dbName, copyName, filterTombstones, placement, interval, q, n }) {
     assert(couchUrl, 'The Continuum requires a URL for accessing CouchDB.')
     assert(dbName, 'The Continuum requires a target database.')
     this.url = couchUrl
@@ -122,6 +122,7 @@ class CouchContinuum {
     this.db2 = (copyName && encodeURIComponent(copyName)) || (this.db1 + '_temp_copy')
     this.interval = interval || 1000
     this.q = q
+    this.n = n
     this.placement = placement
     this.filterTombstones = filterTombstones
     log('Created new continuum: %j', {
@@ -129,6 +130,7 @@ class CouchContinuum {
       db2: this.db2,
       interval: this.interval,
       q: this.q,
+      n: this.n,
       placement: this.placement
     })
   }
@@ -136,6 +138,7 @@ class CouchContinuum {
   _createDb (dbName) {
     var qs = {}
     if (this.q) qs.q = this.q
+    if (this.n) qs.n = this.n
     if (this.placement) qs.placement = this.placement
     return makeRequest({
       url: [this.url, dbName].join('/'),

--- a/test.js
+++ b/test.js
@@ -82,6 +82,22 @@ describe([name, version].join(' @ '), function () {
     return continuum.createReplica()
   })
 
+  it('should modify n', function () {
+    const options = { couchUrl, dbName, n: 1 }
+    const continuum = new CouchContinuum(options)
+    return continuum.createReplica()
+      .then(() => {
+        return new Promise((resolve, reject) => {
+          const url = [couchUrl, continuum.db2].join('/')
+          request({ url, json: true }, (err, response, { cluster }) => {
+            if (err) return reject(err)
+            else if (cluster.n !== 1) reject(new Error(`n should be 1 but is ${cluster.n}.`))
+            else return resolve()
+          })
+        })
+      })
+  })
+
   it('should migrate all OK', function () {
     this.timeout(30 * 1000)
     return CouchContinuum

--- a/test.js
+++ b/test.js
@@ -90,9 +90,15 @@ describe([name, version].join(' @ '), function () {
         return new Promise((resolve, reject) => {
           const url = [couchUrl, continuum.db2].join('/')
           request({ url, json: true }, (err, response, { cluster }) => {
-            if (err) return reject(err)
-            else if (cluster.n !== 1) reject(new Error(`n should be 1 but is ${cluster.n}.`))
-            else return resolve()
+            if (err) {
+              return reject(err)
+            } else if (cluster === undefined) {
+              return resolve() // 1.x, travis
+            } else if (cluster.n !== 1) {
+              return reject(new Error(`n should be 1 but is ${cluster.n}.`))
+            } else {
+              return resolve()
+            }
           })
         })
       })


### PR DESCRIPTION
This PR closes #31 by changing the `dbName` alias to `N`, and assigning the `n` flag to set the `n` value for the new database. It also adds a test to verify this, which can be run against a cluster by setting the `COUCH_URL` variable and running the test suite like this:

```bash
$ COUCH_URL=... npm test
```