### PR TITLE
[skip ci] fix: broken readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ npm test
 
 ## Contributions
 
-All contributions are welcome: bug reports, feature requests, "why doesn't this work" questions, patches for fixes and features, etc. For all of the above, [file an issue](https://github.com/garbados/mastermind-game/issues) or [submit a pull request](https://github.com/garbados/mastermind-game/pulls).
+All contributions are welcome: bug reports, feature requests, "why doesn't this work" questions, patches for fixes and features, etc. For all of the above, [file an issue](https://github.com/neighbourhoodie/couch-continuum/issues) or [submit a pull request](https://github.com/neighbourhoodie/couch-continuum/pulls).
 
 ## License
 


### PR DESCRIPTION
Some links went to the wrong repo. This PR fixes that so they point to couch-continuum.