### PR TITLE
feat: copy security object during replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,22 +84,26 @@ Commands:
                                    settings.                      [aliases: all]
 
 Options:
-  --version               Show version number                          [boolean]
-  --couchUrl, -u          The URL of the CouchDB cluster to act upon.
+  --version                Show version number                         [boolean]
+  --couchUrl, -u           The URL of the CouchDB cluster to act upon.
                                [default: "http://admin:password@localhost:5984"]
-  --interval, -i          How often (in milliseconds) to check replication tasks
-                          for progress.                          [default: 1000]
-  -q                      The desired "q" value for the new database.   [number]
-  -n                      The desired "n" value for the new database.   [number]
-  --verbose, -v           Enable verbose logging.                      [boolean]
-  --placement, -p         Placement rule for the affected database(s).  [string]
-  --filterTombstones, -f  Filter tombstones during replica creation.
-                                                                [default: false]
-  --config                Path to JSON config file
-  --dbName, -N            The name of the database to modify.[string] [required]
-  --copyName, -c          The name of the database to use as a replica. Defaults
-                          to {dbName}_temp_copy                         [string]
-  -h, --help              Show help                                    [boolean]
+  --interval, -i           How often (in milliseconds) to check replication
+                           tasks for progress.                   [default: 1000]
+  -q                       The desired "q" value for the new database.  [number]
+  -n                       The desired "n" value for the new database.  [number]
+  --verbose, -v            Enable verbose logging.                     [boolean]
+  --placement, -p          Placement rule for the affected database(s). [string]
+  --filterTombstones, -f   Filter tombstones during replica creation. Does not
+                           work with CouchDB 1.x                [default: false]
+  --replicateSecurity, -r  Replicate a database's /_security object in addition
+                           to its documents.                    [default: false]
+  --config                 Path to JSON config file
+  --dbName, -N             The name of the database to modify.
+                                                             [string] [required]
+  --copyName, -c           The name of the database to use as a replica.
+                           Defaults to {dbName}_temp_copy               [string]
+  -h, --help               Show help                                   [boolean]
+
 ```
 
 The verbose output will inform you of each stage of the tool's operations. For example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "couch-continuum",
-  "version": "2.0.0-alpha",
+  "version": "2.0.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -153,4 +153,21 @@ describe([name, version].join(' @ '), function () {
     available = await continuum._isAvailable()
     assert.strictEqual(available, true)
   })
+
+  it('should replicate security OK', async function () {
+    const continuum = new CouchContinuum({ couchUrl, dbName, replicateSecurity: true })
+    const security = { members: { roles: ['hello'], names: ['world'] } }
+    await request({
+      url: `${couchUrl}/${dbName}/_security`,
+      method: 'PUT',
+      json: security
+    })
+    await continuum.createReplica()
+    const replicaSec = await request({
+      url: `${couchUrl}/${dbName}_temp_copy/_security`,
+      json: true
+    })
+    assert.strictEqual(security.members.roles[0], replicaSec.members.roles[0])
+    assert.strictEqual(security.members.names[0], replicaSec.members.names[0])
+  })
 })


### PR DESCRIPTION
This PR closes #39 by adding a `-r, --replicateSecurity` option which tells the continuum to replicate a database's `/_security` object after replicating its documents. By default, security is not replicated in order to avoid accidental overwrites.