### PR TITLE
feat: use remote URLs for sources and targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Commands:
 
 Options:
   --version               Show version number                          [boolean]
+  --source, -s            The name or URL of a database to use as a primary.
+                                                             [string] [required]
+  --target, -t            The name or URL of a database to use as a replica.
+                          Defaults to {source}_temp_copy                [string]
   --couchUrl, -u          The URL of the CouchDB cluster to act upon.
                                [default: "http://admin:password@localhost:5984"]
   --interval, -i          How often (in milliseconds) to check replication tasks
@@ -93,42 +97,45 @@ Options:
   -n                      The desired "n" value for the new database.   [number]
   --verbose, -v           Enable verbose logging.                      [boolean]
   --placement, -p         Placement rule for the affected database(s).  [string]
-  --filterTombstones, -f  Filter tombstones during replica creation.
-                                                                [default: false]
+  --filterTombstones, -f  Filter tombstones during replica creation. Does not
+                          work with CouchDB 1.x                 [default: false]
   --config                Path to JSON config file
-  --dbName, -N            The name of the database to modify.[string] [required]
-  --copyName, -c          The name of the database to use as a replica. Defaults
-                          to {dbName}_temp_copy                         [string]
   -h, --help              Show help                                    [boolean]
 ```
 
 The verbose output will inform you of each stage of the tool's operations. For example:
 
 ```
-$ couch-continuum -N hello-world -q 4 -u http://... -v
-[couch-continuum] Created new continuum: {"db1":"hello-world","db2":"hello-world_temp_copy","interval":1000,"q":4,"n":1}
-[couch-continuum] Migrating database 'hello-world'...
-[couch-continuum] Creating replica hello-world_temp_copy...
+$ couch-continuum -s hello-world -q 4 -u https://... -v
+[couch-continuum] Created new continuum: {
+  "url": "localhost:5984",
+  "source": "localhost:5984/hello-world",
+  "target": "localhost:5984/hello-world_temp_copy",
+  "interval": 1000,
+  "q": 4
+}
+[couch-continuum] Migrating database: localhost:5984/hello-world
+[couch-continuum] Creating replica localhost:5984/hello-world_temp_copy...
 [couch-continuum] [0/5] Checking if primary is in use...
-[couch-continuum] [1/5] Creating replica db: hello-world_temp_copy
+[couch-continuum] [1/5] Creating replica db: localhost:5984/hello-world_temp_copy
 [couch-continuum] [2/5] Beginning replication of primary to replica...
 [couch-continuum] [3/5] Verifying primary did not change during replication...
 [couch-continuum] [4/5] Verifying primary and replica match...
 [couch-continuum] [5/5] Primary copied to replica.
 Ready to replace the primary with the replica. Continue? [y/N] y
-[couch-continuum] Replacing primary hello-world...
+[couch-continuum] Replacing primary localhost:5984/hello-world using localhost:5984/hello-world_temp_copy...
 [couch-continuum] [0/8] Checking if primary is in use...
 [couch-continuum] [1/8] Verifying primary and replica match...
 [couch-continuum] [2/8] Destroying primary...
 [couch-continuum] [3/8] Recreating primary with new settings...
-[couch-continuum] Recreating primary hello-world
+[couch-continuum] Recreating primary localhost:5984/hello-world
 [couch-continuum] (====================) 100% 0.0s
 [couch-continuum] [4/8] Setting primary to unavailable.
 [couch-continuum] [5/8] Beginning replication of replica to primary...
 [couch-continuum] [6/8] Replicated. Destroying replica...
 [couch-continuum] [7/8] Setting primary to available.
 [couch-continuum] [8/8] Primary migrated to new settings.
-[couch-continuum] ... success!
+Migrated database: localhost:5984/hello-world
 ```
 
 ## Why "Continuum"?

--- a/README.md
+++ b/README.md
@@ -84,23 +84,26 @@ Commands:
                                    settings.                      [aliases: all]
 
 Options:
-  --version               Show version number                          [boolean]
-  --source, -s            The name or URL of a database to use as a primary.
-                                                             [string] [required]
-  --target, -t            The name or URL of a database to use as a replica.
-                          Defaults to {source}_temp_copy                [string]
-  --couchUrl, -u          The URL of the CouchDB cluster to act upon.
+  --version                     Show version number                    [boolean]
+  --source, --dbNames, -N, -s   The name or URL of a database to use as a
+                                primary.                     [string] [required]
+  --target, --copyName, -c, -t  The name or URL of a database to use as a
+                                replica. Defaults to {source}_temp_copy [string]
+  --couchUrl, -u                The URL of the CouchDB cluster to act upon.
                                [default: "http://admin:password@localhost:5984"]
-  --interval, -i          How often (in milliseconds) to check replication tasks
-                          for progress.                          [default: 1000]
-  -q                      The desired "q" value for the new database.   [number]
-  -n                      The desired "n" value for the new database.   [number]
-  --verbose, -v           Enable verbose logging.                      [boolean]
-  --placement, -p         Placement rule for the affected database(s).  [string]
-  --filterTombstones, -f  Filter tombstones during replica creation. Does not
-                          work with CouchDB 1.x                 [default: false]
-  --config                Path to JSON config file
-  -h, --help              Show help                                    [boolean]
+  --interval, -i                How often (in milliseconds) to check replication
+                                tasks for progress.              [default: 1000]
+  -q                            The desired "q" value for the new database.
+                                                                        [number]
+  -n                            The desired "n" value for the new database.
+                                                                        [number]
+  --verbose, -v                 Enable verbose logging.                [boolean]
+  --placement, -p               Placement rule for the affected database(s).
+                                                                        [string]
+  --filterTombstones, -f        Filter tombstones during replica creation. Does
+                                not work with CouchDB 1.x       [default: false]
+  --config                      Path to JSON config file
+  -h, --help                    Show help                              [boolean]
 ```
 
 The verbose output will inform you of each stage of the tool's operations. For example:

--- a/bin.js
+++ b/bin.js
@@ -148,6 +148,12 @@ require('yargs')
       } catch (error) { catchError(error) }
     }
   })
+  // backwards compat with old flag names
+  .alias('source', 'dbNames')
+  .alias('source', 'N')
+  .alias('target', 'copyName')
+  .alias('target', 'c')
+  // actual options
   .options({
     source: {
       alias: 's',

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ class CouchContinuum {
     // what's great for a snack and fits on your back
     // it's log it's log it's log
     // everyone wants a log
-    const options = {
+    log(`Created new continuum: ${JSON.stringify({
       filterTombstones: this.filterTombstones,
       interval: this.interval,
       n: this.n,
@@ -140,8 +140,7 @@ class CouchContinuum {
       source: `${this.source.host}${this.source.path}`,
       target: `${this.target.host}${this.target.path}`,
       url: this.url.host
-    }
-    log(`Created new continuum: ${JSON.stringify(options, undefined, 2)}`)
+    }, undefined, 2)}`)
   }
 
   async _createDb (dbUrl) {

--- a/test/index.js
+++ b/test/index.js
@@ -51,7 +51,7 @@ describe([name, version].join(' @ '), function () {
   })
 
   it('should create replicas repeatedly OK', async function () {
-    const options = { couchUrl, dbName, q }
+    const options = { couchUrl, source: dbName, q }
     const continuum = new CouchContinuum(options)
     await continuum.createReplica()
     await continuum.createReplica()
@@ -59,7 +59,7 @@ describe([name, version].join(' @ '), function () {
 
   it('should replicate and replace a primary', async function () {
     this.timeout(30 * 1000) // 30s
-    const options = { couchUrl, dbName, q }
+    const options = { couchUrl, source: dbName, q }
     const continuum = new CouchContinuum(options)
     // create a replica and replace the primary
     await continuum.createReplica()
@@ -70,13 +70,13 @@ describe([name, version].join(' @ '), function () {
   })
 
   it('should check if a db is in use', async function () {
-    const continuum = new CouchContinuum({ couchUrl, dbName, q })
+    const continuum = new CouchContinuum({ couchUrl, source: dbName, q })
     await continuum._isInUse(dbName)
   })
 
   it('should filter tombstones', async function () {
     if (this.couchVersion < '2') return this.skip() // 1.x needs a special index
-    const options = { couchUrl, dbName, filterTombstones: true }
+    const options = { couchUrl, source: dbName, filterTombstones: true }
     // get tombstone
     const doc = await request({ url: `${couchUrl}/${dbName}/doc_1`, json: true })
     await request({ url: `${couchUrl}/${dbName}/doc_1?rev=${doc._rev}`, method: 'DELETE' })
@@ -96,7 +96,7 @@ describe([name, version].join(' @ '), function () {
   })
 
   it('should modify n', async function () {
-    const options = { couchUrl, dbName, n: 1 }
+    const options = { couchUrl, source: dbName, n: 1 }
     const continuum = new CouchContinuum(options)
     await continuum.createReplica()
     const url = [couchUrl, continuum.db2].join('/')
@@ -109,7 +109,7 @@ describe([name, version].join(' @ '), function () {
 
   it('should migrate all OK', async function () {
     this.timeout(30 * 1000)
-    const continuums = [new CouchContinuum({ couchUrl, dbName, q })]
+    const continuums = [new CouchContinuum({ couchUrl, source: dbName, q })]
     await CouchContinuum.createReplicas(continuums)
     await CouchContinuum.replacePrimaries(continuums)
   })
@@ -130,27 +130,39 @@ describe([name, version].join(' @ '), function () {
   })
 
   it('should handle availability OK', async function () {
-    const continuum = new CouchContinuum({ couchUrl, dbName })
-    let available = await continuum._isAvailable()
+    const continuum = new CouchContinuum({ couchUrl, source: dbName })
+    let available = await CouchContinuum._isAvailable(continuum.source.href)
     // available by default
     assert.strictEqual(available, true)
     // sets from undefined ok
-    await continuum._setAvailable()
-    available = await continuum._isAvailable()
+    await CouchContinuum._setAvailable(continuum.source.href)
+    available = await CouchContinuum._isAvailable(continuum.source.href)
     assert.strictEqual(available, true)
     // sets unavailable consecutively ok
-    await continuum._setUnavailable()
-    available = await continuum._isAvailable()
+    await CouchContinuum._setUnavailable(continuum.source.href)
+    available = await CouchContinuum._isAvailable(continuum.source.href)
     assert.strictEqual(available, false)
-    await continuum._setUnavailable()
-    available = await continuum._isAvailable()
+    await CouchContinuum._setUnavailable(continuum.source.href)
+    available = await CouchContinuum._isAvailable(continuum.source.href)
     assert.strictEqual(available, false)
     // sets available consecutively ok
-    await continuum._setAvailable()
-    available = await continuum._isAvailable()
+    await CouchContinuum._setAvailable(continuum.source.href)
+    available = await CouchContinuum._isAvailable(continuum.source.href)
     assert.strictEqual(available, true)
-    await continuum._setAvailable()
-    available = await continuum._isAvailable()
+    await CouchContinuum._setAvailable(continuum.source.href)
+    available = await CouchContinuum._isAvailable(continuum.source.href)
     assert.strictEqual(available, true)
+  })
+
+  it('should handle remote source and target URLs', function () {
+    const source = 'http://localhost:5985/hello-world'
+    const target = 'http://localhost:5986/ahoy-planet'
+    const continuum = new CouchContinuum({ couchUrl, source, target })
+    assert.strictEqual(continuum.source.port, '5985')
+    assert.strictEqual(continuum.target.port, '5986')
+    // also works with local target
+    const localTarget = 'ahoy-planet'
+    const continuum2 = new CouchContinuum({ couchUrl, source, target: localTarget })
+    assert.strictEqual(continuum2.target.port, continuum2.url.port)
   })
 })


### PR DESCRIPTION
This PR closes #41 by changing the `--dbName` and `--copyName` arguments to `--source` and `--target` respectively, which can be either the names of local databases or URLs to remote ones. If the argument is not a fully-qualified URL, it is augmented using the `--couchUrl` argument (which is always a URL) to create a full URL.