### PR TITLE
fix: improve failure logging

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
+const assert = require('assert').strict
 const readline = require('readline')
 
 const CouchContinuum = require('.')
@@ -60,7 +61,7 @@ function catchError (error) {
   } else if (error.code === 'EACCES') {
     console.log('Could not access the checkpoint document. Are you running as a different user?')
   } else {
-    console.log('Unexpected error: %j', error)
+    assert.fail(`Unexpected error: ${JSON.stringify(error)}`)
   }
   process.exit(1)
 }

--- a/bin.js
+++ b/bin.js
@@ -62,20 +62,18 @@ require('yargs')
     description: 'Migrate a database to new settings.',
     handler: async function (argv) {
       const continuum = getContinuum(argv)
-      log(`Migrating database: ${continuum.source.host}${continuum.source.path}`)
-      await continuum.createReplica()
-      const consent = await getConsent()
-      if (!consent) return log('Could not acquire consent. Exiting...')
-      await continuum.replacePrimary()
-      console.log(`Migrated database: ${continuum.source.host}${continuum.source.path}`)
       log(`Migrating database: ${continuum.source.host}${continuum.source.pathname}`)
-      try {
-        await continuum.createReplica()
-        const consent = await getConsent()
-        if (!consent) return log('Could not acquire consent. Exiting...')
-        await continuum.replacePrimary()
-        console.log(`Migrated database: ${continuum.source.host}${continuum.source.pathname}`)
-      } catch (error) { catchError(error) }
+      await continuum.createReplica()
+      const consent1 = await getConsent()
+      if (!consent1) return log('Could not acquire consent. Exiting...')
+      await continuum.replacePrimary()
+      console.log(`Migrated database: ${continuum.source.host}${continuum.source.pathname}`)
+      log(`Migrating database: ${continuum.source.host}${continuum.source.pathname}`)
+      await continuum.createReplica()
+      const consent2 = await getConsent()
+      if (!consent2) return log('Could not acquire consent. Exiting...')
+      await continuum.replacePrimary()
+      console.log(`Migrated database: ${continuum.source.host}${continuum.source.pathname}`)
     }
   })
   .command({
@@ -84,14 +82,12 @@ require('yargs')
     description: 'Create a replica of the given primary.',
     handler: async function (argv) {
       const continuum = getContinuum(argv)
-      log(`Creating replica of ${continuum.source.host}${continuum.source.path} at ${continuum.target.host}${continuum.target.path}`)
-      await continuum.createReplica()
-      console.log(`Created replica of ${continuum.source.host}${continuum.source.path}`)
       log(`Creating replica of ${continuum.source.host}${continuum.source.pathname} at ${continuum.target.host}${continuum.target.pathname}`)
-      try {
-        await continuum.createReplica()
-        console.log(`Created replica of ${continuum.source.host}${continuum.source.path}`)
-      } catch (error) { catchError(error) }
+      await continuum.createReplica()
+      console.log(`Created replica of ${continuum.source.host}${continuum.source.pathname}`)
+      log(`Creating replica of ${continuum.source.host}${continuum.source.pathname} at ${continuum.target.host}${continuum.target.pathname}`)
+      await continuum.createReplica()
+      console.log(`Created replica of ${continuum.source.host}${continuum.source.pathname}`)
     }
   })
   .command({
@@ -100,11 +96,11 @@ require('yargs')
     description: 'Replace the given primary with the indicated replica.',
     handler: async function (argv) {
       const continuum = getContinuum(argv)
-      log(`Replacing primary ${continuum.source.host}${continuum.source.path} with ${continuum.target.host}${continuum.target.path}`)
+      log(`Replacing primary ${continuum.source.host}${continuum.source.pathname} with ${continuum.target.host}${continuum.target.pathname}`)
       const consent = await getConsent()
       if (!consent) return log('Could not acquire consent. Exiting...')
       await continuum.replacePrimary()
-      console.log(`Successfully replaced ${continuum.source.host}${continuum.source.path}`)
+      console.log(`Successfully replaced ${continuum.source.host}${continuum.source.pathname}`)
     }
   })
   .command({
@@ -188,7 +184,9 @@ require('yargs')
   .config()
   .alias('h', 'help')
   .fail((msg, error, yargs) => {
-    if (error.error === 'not_found') {
+    if (!error) {
+      console.log(msg)
+    } else if (error.error === 'not_found') {
       console.log('Primary database does not exist. There is nothing to migrate.')
     } else if (error.error === 'unauthorized') {
       console.log('Could not authenticate with CouchDB. Are the credentials correct?')

--- a/bin.js
+++ b/bin.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict'
 
-const assert = require('assert').strict
 const readline = require('readline')
 
 const CouchContinuum = require('.')
@@ -52,20 +51,6 @@ async function getConsent (question) {
   })
 }
 
-function catchError (error) {
-  console.log('ERROR')
-  if (error.error === 'not_found') {
-    console.log('Primary database does not exist. There is nothing to migrate.')
-  } else if (error.error === 'unauthorized') {
-    console.log('Could not authenticate with CouchDB. Are the credentials correct?')
-  } else if (error.code === 'EACCES') {
-    console.log('Could not access the checkpoint document. Are you running as a different user?')
-  } else {
-    assert.fail(`Unexpected error: ${JSON.stringify(error)}`)
-  }
-  process.exit(1)
-}
-
 /*
 MAIN
  */
@@ -78,13 +63,11 @@ require('yargs')
     handler: async function (argv) {
       const continuum = getContinuum(argv)
       log(`Migrating database: ${continuum.source.host}${continuum.source.path}`)
-      try {
-        await continuum.createReplica()
-        const consent = await getConsent()
-        if (!consent) return log('Could not acquire consent. Exiting...')
-        await continuum.replacePrimary()
-        console.log(`Migrated database: ${continuum.source.host}${continuum.source.path}`)
-      } catch (error) { catchError(error) }
+      await continuum.createReplica()
+      const consent = await getConsent()
+      if (!consent) return log('Could not acquire consent. Exiting...')
+      await continuum.replacePrimary()
+      console.log(`Migrated database: ${continuum.source.host}${continuum.source.path}`)
     }
   })
   .command({
@@ -94,10 +77,8 @@ require('yargs')
     handler: async function (argv) {
       const continuum = getContinuum(argv)
       log(`Creating replica of ${continuum.source.host}${continuum.source.path} at ${continuum.target.host}${continuum.target.path}`)
-      try {
-        await continuum.createReplica()
-        console.log(`Created replica of ${continuum.source.host}${continuum.source.path}`)
-      } catch (error) { catchError(error) }
+      await continuum.createReplica()
+      console.log(`Created replica of ${continuum.source.host}${continuum.source.path}`)
     }
   })
   .command({
@@ -107,12 +88,10 @@ require('yargs')
     handler: async function (argv) {
       const continuum = getContinuum(argv)
       log(`Replacing primary ${continuum.source.host}${continuum.source.path} with ${continuum.target.host}${continuum.target.path}`)
-      try {
-        const consent = await getConsent()
-        if (!consent) return log('Could not acquire consent. Exiting...')
-        await continuum.replacePrimary()
-        console.log(`Successfully replaced ${continuum.source.host}${continuum.source.path}`)
-      } catch (error) { catchError(error) }
+      const consent = await getConsent()
+      if (!consent) return log('Could not acquire consent. Exiting...')
+      await continuum.replacePrimary()
+      console.log(`Successfully replaced ${continuum.source.host}${continuum.source.path}`)
     }
   })
   .command({
@@ -122,20 +101,18 @@ require('yargs')
     handler: async function (argv) {
       const { couchUrl, verbose } = argv
       if (verbose) { process.env.LOG = true }
-      try {
-        const dbNames = await CouchContinuum.getRemaining(couchUrl)
-        const continuums = dbNames.map((dbName) => {
-          return new CouchContinuum({ dbName, ...argv })
-        })
-        log('Creating replicas...')
-        await CouchContinuum.createReplicas(continuums)
-        const consent = await getConsent('Ready to replace primaries with replicas. Continue? [y/N] ')
-        if (!consent) return console.log('Could not acquire consent. Exiting...')
-        log('Replacing primaries...')
-        await CouchContinuum.replacePrimaries(continuums)
-        await CouchContinuum.removeCheckpoint()
-        console.log(`Successfully migrated databases: ${dbNames.join(', ')}`)
-      } catch (error) { catchError(error) }
+      const dbNames = await CouchContinuum.getRemaining(couchUrl)
+      const continuums = dbNames.map((dbName) => {
+        return new CouchContinuum({ dbName, ...argv })
+      })
+      log('Creating replicas...')
+      await CouchContinuum.createReplicas(continuums)
+      const consent = await getConsent('Ready to replace primaries with replicas. Continue? [y/N] ')
+      if (!consent) return console.log('Could not acquire consent. Exiting...')
+      log('Replacing primaries...')
+      await CouchContinuum.replacePrimaries(continuums)
+      await CouchContinuum.removeCheckpoint()
+      console.log(`Successfully migrated databases: ${dbNames.join(', ')}`)
     }
   })
   // backwards compat with old flag names
@@ -197,4 +174,17 @@ require('yargs')
   })
   .config()
   .alias('h', 'help')
+  .fail((msg, error, yargs) => {
+    if (error.error === 'not_found') {
+      console.log('Primary database does not exist. There is nothing to migrate.')
+    } else if (error.error === 'unauthorized') {
+      console.log('Could not authenticate with CouchDB. Are the credentials correct?')
+    } else if (error.code === 'EACCES') {
+      console.log('Could not access the checkpoint document. Are you running as a different user?')
+    } else {
+      console.log('Unexpected error. Please report this so we can fix it!')
+      console.log(error)
+    }
+    process.exit(1)
+  })
   .parse()

--- a/index.js
+++ b/index.js
@@ -308,8 +308,13 @@ class CouchContinuum {
       }).then(({ jobs }) => {
         return { jobs: jobs || [] }
       })
-      for (const { database } of [...jobs, ...activeTasks]) {
-        assert.notStrictEqual(database, dbName, `${dbName} is still in use.`)
+      for (const { database, source, target } of [...jobs, ...activeTasks]) {
+        const re = new RegExp(`/${dbName}/`)
+        if (database) {
+          assert.strictEqual(re.test(database), true)
+        }
+        assert.strictEqual(re.test(source), true)
+        assert.strictEqual(re.test(target), true)
       }
     } catch (error) {
       if (error.error === 'illegal_database_name') {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const assert = require('assert')
+const assert = require('assert').strict
 const path = require('path')
 const ProgressBar = require('progress')
 const { URL, format: urlFormat } = require('url')

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,7 +4,23 @@ module.exports = async function (options) {
   return new Promise((resolve, reject) => {
     request(options, (err, res, body) => {
       if (err) return reject(err)
-      return resolve(body)
+      if (res.statusCode >= 400) {
+        let string, json
+        if (typeof body === 'string') {
+          string = body
+          json = { options, ...JSON.parse(body) }
+        } else {
+          string = JSON.stringify(body)
+          json = { options, ...body }
+        }
+        const error = new Error(string)
+        Object.entries(json).map(([prop, value]) => {
+          error[prop] = value
+        })
+        return reject(error)
+      } else {
+        return resolve(body)
+      }
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "couch-continuum": "bin.js"
   },
   "scripts": {
-    "test": "standard && dependency-check . --unused --no-dev && mocha && npm audit"
+    "test": "standard && dependency-check . --unused --no-dev && LOG=true mocha && npm audit"
   },
   "author": "Diana Thayer <garbados@gmail.com>",
   "license": "Apache-2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-/* globals describe, it, beforeEach, before, afterEach */
+/* globals describe, it, beforeEach, before, afterEach, after */
 
 const assert = require('assert').strict
 const CouchContinuum = require('..')
@@ -217,5 +217,30 @@ describe([name, version].join(' @ '), function () {
     await CouchContinuum.makeCheckpoint(checkpoint)
     await CouchContinuum.removeCheckpoint(checkpoint)
     await CouchContinuum.removeCheckpoint(checkpoint)
+  })
+
+  describe('_isInUse', function () {
+    before(async function () {
+      this.continuum = new CouchContinuum({ couchUrl, source: dbName })
+      await this.continuum._createDb(this.continuum.source.href)
+      await this.continuum._createDb(this.continuum.target.href)
+      await request({
+        method: 'POST',
+        url: `${this.continuum.url.href}_replicate`,
+        json: {
+          continuous: true,
+          source: this.continuum.source.href,
+          target: this.continuum.target.href
+        }
+      })
+    })
+
+    it('should check for databases in use', function () {
+      assert.rejects(this.continuum._isInUse(dbName))
+    })
+
+    after(async function () {
+      await this.promise
+    })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* globals describe, it, beforeEach, before, afterEach */
 
-const assert = require('assert')
+const assert = require('assert').strict
 const CouchContinuum = require('..')
 const request = require('../lib/request')
 const { name, version } = require('../package.json')

--- a/test/index.js
+++ b/test/index.js
@@ -211,4 +211,11 @@ describe([name, version].join(' @ '), function () {
     })
     await continuum.createReplica()
   })
+
+  it('should handle removing a checkpoint more than once', async function () {
+    const checkpoint = '.testcheckpoint'
+    await CouchContinuum.makeCheckpoint(checkpoint)
+    await CouchContinuum.removeCheckpoint(checkpoint)
+    await CouchContinuum.removeCheckpoint(checkpoint)
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -201,4 +201,14 @@ describe([name, version].join(' @ '), function () {
     assert.strictEqual(security.members.roles[0], replicaSec.members.roles[0])
     assert.strictEqual(security.members.names[0], replicaSec.members.names[0])
   })
+
+  it('should run timer code', async function () {
+    const interval = 1
+    const continuum = new CouchContinuum({
+      couchUrl,
+      source: dbName,
+      interval
+    })
+    await continuum.createReplica()
+  })
 })


### PR DESCRIPTION
Pursuant to https://github.com/neighbourhoodie/couch-continuum/issues/64#issuecomment-624666140 , this PR will make the reporting of unexpected errors clearer and include a proper stacktrace. It does this by utilizing yarg's "fail" setting, which fires if any task errors out, rather than wrapping individual tasks in try/catch blocks.

Currently the test suite fails because the continuum now catches errors more strictly, and so needs more specific handling in some places. I've encountered a testing issue where a database seems to both exist and not exist at the same time, so I'm going to give it a rest and revisit it tomorrow when (I hope) Schrödinger has stopped messing with my code.

This PR closes https://github.com/neighbourhoodie/couch-continuum/issues/65